### PR TITLE
Configure dependabot to check for new GitHub action versions daily

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Saw a couple of outdated versions. Thought that dependabot might be able to help out keeping things up to date.