### PR TITLE
chore: Update packaging jobs

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: git fetch --tags
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -7,11 +7,11 @@ on:
       requirements_file:
         type: "string"
         required: false
-        default: "setup.cfg"
+        default: "pyproject.toml"
       python-version:
         type: "string"
         required: false
-        default: "3.11"
+        default: "3.12"
 
 jobs:
   build-and-publish:

--- a/.github/workflows/python-test-build.yaml
+++ b/.github/workflows/python-test-build.yaml
@@ -4,11 +4,11 @@ on:
       requirements_file:
         type: "string"
         required: false
-        default: "setup.cfg"
+        default: "pyproject.toml"
       python-version:
         type: "string"
         required: false
-        default: "3.11"
+        default: "3.12"
 
 jobs:
   build-and-check:
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: git fetch --tags
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
- Default to Python 3.12.
- Default to use pyproject.toml as requirements file.
- Fetch all tags to allow VCS versioning.